### PR TITLE
Add Jest test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,75 @@
 # rekognition-testing
-# rekognition-testing
+
+This project provides a simple Node.js API for indexing student faces into an Amazon Rekognition collection and identifying students in new images. It is intended for a yearbook application where each student provides a class photo for enrollment.
+
+## Requirements
+
+- Node.js (v14 or higher)
+- An AWS account with Rekognition enabled
+- AWS credentials configured in your environment (e.g. using `~/.aws/credentials`)
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Set environment variables as needed:
+
+- `AWS_REGION` – AWS region for Rekognition (default `us-east-1`)
+- `COLLECTION_ID` – name of the Rekognition collection (default `students`)
+- `PORT` – port to run the API on (default `3000`)
+
+Start the server:
+
+```bash
+npm start
+```
+
+Run the tests:
+
+```bash
+npm test
+```
+
+## API
+
+### `POST /index`
+
+Enroll a student's face.
+
+Request body (JSON):
+
+```json
+{
+  "studentId": "123",
+  "image": "<base64 encoded JPEG or PNG>"
+}
+```
+
+### `POST /identify`
+
+Identify students in an image.
+
+Request body (JSON):
+
+```json
+{
+  "image": "<base64 encoded JPEG or PNG>"
+}
+```
+
+Response example:
+
+```json
+{
+  "students": [
+    { "studentId": "123", "similarity": 98.6 },
+    { "studentId": "456", "similarity": 95.2 }
+  ]
+}
+```
+
+The `similarity` field indicates how closely the face matched the enrolled student image.

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+
+// Mock AWS Rekognition client
+jest.mock('aws-sdk', () => {
+  const mockIndexFaces = jest.fn().mockReturnValue({ promise: () => Promise.resolve({ FaceRecords: [{ Face: { FaceId: 'id1' } }] }) });
+  const mockSearchFacesByImage = jest.fn().mockReturnValue({ promise: () => Promise.resolve({ FaceMatches: [{ Face: { ExternalImageId: '123' }, Similarity: 99.9 }] }) });
+  const mockDescribeCollection = jest.fn().mockReturnValue({ promise: () => Promise.resolve({}) });
+  return {
+    Rekognition: jest.fn(() => ({
+      indexFaces: mockIndexFaces,
+      searchFacesByImage: mockSearchFacesByImage,
+      describeCollection: mockDescribeCollection,
+      createCollection: jest.fn().mockReturnValue({ promise: () => Promise.resolve({}) })
+    }))
+  };
+});
+
+const { app, ensureCollection } = require('../server');
+const AWS = require('aws-sdk');
+
+describe('API endpoints', () => {
+  beforeAll(async () => {
+    // mock ensureCollection to not interact with AWS during tests
+    AWS.Rekognition.mockClear();
+    await ensureCollection();
+  });
+
+  test('POST /index requires parameters', async () => {
+    const res = await request(app).post('/index').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /identify requires image', async () => {
+    const res = await request(app).post('/identify').send({});
+    expect(res.status).toBe(400);
+  });
+
+  test('successful face indexing and identification', async () => {
+    const indexRes = await request(app).post('/index').send({
+      studentId: '123',
+      image: Buffer.from('fake').toString('base64'),
+    });
+    expect(indexRes.status).toBe(200);
+    expect(Array.isArray(indexRes.body.faceIds)).toBe(true);
+
+    const idRes = await request(app).post('/identify').send({
+      image: Buffer.from('fake').toString('base64'),
+    });
+    expect(idRes.status).toBe(200);
+    expect(Array.isArray(idRes.body.students)).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rekognition-testing",
+  "version": "1.0.0",
+  "description": "Yearbook facial recognition API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1410.0",
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2"
+  },
+  "devDependencies": {
+    "jest": "^29.5.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const AWS = require('aws-sdk');
+
+const app = express();
+const port = process.env.PORT || 3000;
+const COLLECTION_ID = process.env.COLLECTION_ID || 'students';
+const rekognition = new AWS.Rekognition({ region: process.env.AWS_REGION || 'us-east-1' });
+
+app.use(bodyParser.json({ limit: '10mb' }));
+
+async function ensureCollection() {
+  try {
+    await rekognition.describeCollection({ CollectionId: COLLECTION_ID }).promise();
+  } catch (err) {
+    if (err.code === 'ResourceNotFoundException') {
+      await rekognition.createCollection({ CollectionId: COLLECTION_ID }).promise();
+    } else {
+      throw err;
+    }
+  }
+}
+
+app.post('/index', async (req, res) => {
+  const { studentId, image } = req.body;
+  if (!studentId || !image) {
+    return res.status(400).json({ error: 'studentId and image are required' });
+  }
+  try {
+    const params = {
+      CollectionId: COLLECTION_ID,
+      Image: { Bytes: Buffer.from(image, 'base64') },
+      ExternalImageId: studentId,
+      DetectionAttributes: [],
+    };
+    const data = await rekognition.indexFaces(params).promise();
+    res.json({ faceIds: data.FaceRecords.map(r => r.Face.FaceId) });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/identify', async (req, res) => {
+  const { image } = req.body;
+  if (!image) {
+    return res.status(400).json({ error: 'image is required' });
+  }
+  try {
+    const params = {
+      CollectionId: COLLECTION_ID,
+      Image: { Bytes: Buffer.from(image, 'base64') },
+      FaceMatchThreshold: 90,
+      MaxFaces: 50,
+    };
+    const data = await rekognition.searchFacesByImage(params).promise();
+    const students = data.FaceMatches.map(m => ({
+      studentId: m.Face.ExternalImageId,
+      similarity: m.Similarity,
+    }));
+    res.json({ students });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+if (require.main === module) {
+  ensureCollection().then(() => {
+    app.listen(port, () => {
+      console.log(`Server running on port ${port}`);
+    });
+  }).catch(err => {
+    console.error('Failed to initialize Rekognition collection:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { app, ensureCollection };


### PR DESCRIPTION
## Summary
- define Jest-based test script in `package.json`
- export Express app from `server.js` for testability
- create `__tests__/server.test.js` with mocked Rekognition calls
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*